### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.7'
+          cache: true
+      - run: go version
+      - run: go mod download
+      - run: CGO_ENABLED=0 go vet ./...
+      - run: CGO_ENABLED=0 go test ./... -v


### PR DESCRIPTION
Fixes #3

## Summary
- add GitHub Actions workflow to run vet and tests
- configure Go 1.22.7 toolchain with module caching on CI

## Testing
- GOTOOLCHAIN=go1.22.7 CGO_ENABLED=0 go vet ./...
- GOTOOLCHAIN=go1.22.7 CGO_ENABLED=0 go test ./...
