### PR TITLE
feat: add test consumer and target helpers

### DIFF
--- a/cmd/test-consumer/main.go
+++ b/cmd/test-consumer/main.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultPayloadSize = 5 * 1024 * 1024
+)
+
+type consumerFlags struct {
+	target    string
+	filePath  string
+	useSocks  bool
+	socksAddr string
+	timeout   time.Duration
+}
+
+func parseFlags() consumerFlags {
+	var cfg consumerFlags
+	flag.StringVar(&cfg.target, "target", "http://127.0.0.1:9000/upload", "target upload URL")
+	flag.StringVar(&cfg.filePath, "file", "", "path to payload file (optional)")
+	flag.BoolVar(&cfg.useSocks, "use-socks", false, "route traffic through SOCKS5 proxy")
+	flag.StringVar(&cfg.socksAddr, "socks", "127.0.0.1:1080", "SOCKS5 proxy address")
+	flag.DurationVar(&cfg.timeout, "timeout", 60*time.Second, "request timeout")
+	flag.Parse()
+	return cfg
+}
+
+type uploadResponse struct {
+	BytesReceived int64 `json:"bytes_received"`
+	ServerTimeMS  int64 `json:"server_time_ms"`
+}
+
+func main() {
+	cfg := parseFlags()
+	payloadFile, err := ensurePayload(cfg.filePath)
+	if err != nil {
+		log.Fatalf("prepare payload: %v", err)
+	}
+	if cfg.filePath == "" {
+		log.Printf("generated payload file: %s", payloadFile)
+	}
+	client, err := newHTTPClient(cfg)
+	if err != nil {
+		log.Fatalf("http client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+
+	resp, elapsed, err := performUpload(ctx, client, cfg.target, payloadFile)
+	if err != nil {
+		log.Fatalf("upload failed: %v", err)
+	}
+	mode := "direct"
+	if cfg.useSocks {
+		mode = fmt.Sprintf("SOCKS %s", cfg.socksAddr)
+	}
+	log.Printf("mode: %s", mode)
+	log.Printf("client_time_ms=%d", elapsed.Milliseconds())
+	if elapsed > 0 {
+		throughput := float64(resp.BytesReceived) / (1024 * 1024) / elapsed.Seconds()
+		log.Printf("throughput_mibps=%.2f", throughput)
+	}
+	log.Printf("server_bytes=%d server_time_ms=%d", resp.BytesReceived, resp.ServerTimeMS)
+}
+
+func ensurePayload(path string) (string, error) {
+	if path != "" {
+		return path, nil
+	}
+	name := fmt.Sprintf("test-consumer-%d.txt", time.Now().UnixNano())
+	tmpPath := filepath.Join(os.TempDir(), name)
+	file, err := os.Create(tmpPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	pattern := []byte("The quick brown fox jumps over the lazy dog. ")
+	written := 0
+	for written < defaultPayloadSize {
+		remain := defaultPayloadSize - written
+		chunk := pattern
+		if remain < len(pattern) {
+			chunk = pattern[:remain]
+		}
+		if _, err := file.Write(chunk); err != nil {
+			return "", err
+		}
+		written += len(chunk)
+	}
+	if err := file.Sync(); err != nil {
+		return "", err
+	}
+	return tmpPath, nil
+}
+
+func newHTTPClient(cfg consumerFlags) (*http.Client, error) {
+	transport := &http.Transport{
+		DisableKeepAlives: true,
+	}
+	if cfg.useSocks {
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialViaSocks(ctx, network, cfg.socksAddr, addr)
+		}
+	}
+	return &http.Client{Transport: transport}, nil
+}
+
+func performUpload(ctx context.Context, client *http.Client, target, filePath string) (uploadResponse, time.Duration, error) {
+	var out uploadResponse
+	file, err := os.Open(filePath)
+	if err != nil {
+		return out, 0, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return out, 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, file)
+	if err != nil {
+		return out, 0, err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = info.Size()
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		return out, 0, err
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return out, elapsed, fmt.Errorf("unexpected status %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return out, elapsed, err
+	}
+	return out, elapsed, nil
+}
+
+func dialViaSocks(ctx context.Context, network, socksAddr, destAddr string) (net.Conn, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, network, socksAddr)
+	if err != nil {
+		return nil, err
+	}
+	success := false
+	defer func() {
+		if !success {
+			conn.Close()
+		}
+	}()
+	if err := sendSocksGreeting(conn); err != nil {
+		return nil, err
+	}
+	if err := requestSocksConnect(conn, destAddr); err != nil {
+		return nil, err
+	}
+	success = true
+	return conn, nil
+}
+
+func sendSocksGreeting(rw io.ReadWriter) error {
+	if _, err := rw.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		return err
+	}
+	var resp [2]byte
+	if _, err := io.ReadFull(rw, resp[:]); err != nil {
+		return err
+	}
+	if resp[0] != 0x05 {
+		return errors.New("socks: unexpected version")
+	}
+	if resp[1] != 0x00 {
+		return errors.New("socks: authentication required")
+	}
+	return nil
+}
+
+func requestSocksConnect(conn net.Conn, dest string) error {
+	host, portStr, err := net.SplitHostPort(dest)
+	if err != nil {
+		return err
+	}
+	port, err := parsePort(portStr)
+	if err != nil {
+		return err
+	}
+	buf := []byte{0x05, 0x01, 0x00}
+	ip := net.ParseIP(host)
+	switch {
+	case ip == nil:
+		buf = append(buf, 0x03)
+		buf = append(buf, byte(len(host)))
+		buf = append(buf, host...)
+	case ip.To4() != nil:
+		buf = append(buf, 0x01)
+		buf = append(buf, ip.To4()...)
+	default:
+		buf = append(buf, 0x04)
+		buf = append(buf, ip.To16()...)
+	}
+	buf = append(buf, byte(port>>8), byte(port&0xff))
+	if _, err := conn.Write(buf); err != nil {
+		return err
+	}
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(conn, head); err != nil {
+		return err
+	}
+	if head[0] != 0x05 {
+		return errors.New("socks: unexpected version in reply")
+	}
+	if head[1] != 0x00 {
+		return fmt.Errorf("socks: connect failed with code %d", head[1])
+	}
+	addrType := head[3]
+	var discard int
+	switch addrType {
+	case 0x01:
+		discard = 4
+	case 0x03:
+		var ln [1]byte
+		if _, err := io.ReadFull(conn, ln[:]); err != nil {
+			return err
+		}
+		discard = int(ln[0])
+	case 0x04:
+		discard = 16
+	default:
+		return errors.New("socks: unknown address type")
+	}
+	if discard > 0 {
+		trash := make([]byte, discard)
+		if _, err := io.ReadFull(conn, trash); err != nil {
+			return err
+		}
+	}
+	portBuf := make([]byte, 2)
+	if _, err := io.ReadFull(conn, portBuf); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parsePort(port string) (uint16, error) {
+	if port == "" {
+		return 0, errors.New("empty port")
+	}
+	value, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	if value == 0 {
+		return 0, errors.New("port must be greater than zero")
+	}
+	return uint16(value), nil
+}

--- a/cmd/test-consumer/main_test.go
+++ b/cmd/test-consumer/main_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestPerformUploadDirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer r.Body.Close()
+		resp := uploadResponse{BytesReceived: int64(len(body)), ServerTimeMS: 5}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	file := tempFile(t, 2048)
+	client, err := newHTTPClient(consumerFlags{})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, elapsed, err := performUpload(ctx, client, server.URL, file)
+	if err != nil {
+		t.Fatalf("perform upload: %v", err)
+	}
+	if resp.BytesReceived != 2048 {
+		t.Fatalf("bytes received: %d", resp.BytesReceived)
+	}
+	if elapsed <= 0 {
+		t.Fatalf("expected elapsed > 0")
+	}
+}
+
+func TestPerformUploadViaSocks(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer r.Body.Close()
+		resp := uploadResponse{BytesReceived: int64(len(body)), ServerTimeMS: 7}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer backend.Close()
+
+	socksAddr, stop := startTestSocksProxy(t)
+	defer stop()
+
+	client, err := newHTTPClient(consumerFlags{useSocks: true, socksAddr: socksAddr})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	file := tempFile(t, 1024)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, _, err := performUpload(ctx, client, backend.URL, file)
+	if err != nil {
+		t.Fatalf("perform upload: %v", err)
+	}
+	if resp.BytesReceived != 1024 {
+		t.Fatalf("wrong byte count: %d", resp.BytesReceived)
+	}
+}
+
+func tempFile(t *testing.T, size int) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "consumer-test-*.bin")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer f.Close()
+	payload := bytes.Repeat([]byte("x"), size)
+	if _, err := f.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Remove(f.Name())
+	})
+	return f.Name()
+}
+
+func startTestSocksProxy(t *testing.T) (string, func()) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	stop := make(chan struct{})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				select {
+				case <-stop:
+					return
+				default:
+					t.Logf("accept error: %v", err)
+				}
+				return
+			}
+			go handleSocksConn(t, conn)
+		}
+	}()
+	addr := ln.Addr().String()
+	return addr, func() {
+		close(stop)
+		ln.Close()
+	}
+}
+
+func handleSocksConn(t *testing.T, conn net.Conn) {
+	defer conn.Close()
+	var greeting [3]byte
+	if _, err := io.ReadFull(conn, greeting[:]); err != nil {
+		t.Logf("read greeting: %v", err)
+		return
+	}
+	if greeting[0] != 0x05 {
+		t.Log("bad version")
+		return
+	}
+	if _, err := conn.Write([]byte{0x05, 0x00}); err != nil {
+		t.Logf("write method: %v", err)
+		return
+	}
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(conn, head); err != nil {
+		t.Logf("read head: %v", err)
+		return
+	}
+	addrType := head[3]
+	var host string
+	switch addrType {
+	case 0x01:
+		var buf [4]byte
+		if _, err := io.ReadFull(conn, buf[:]); err != nil {
+			t.Logf("ipv4: %v", err)
+			return
+		}
+		host = net.IP(buf[:]).String()
+	case 0x03:
+		var ln [1]byte
+		if _, err := io.ReadFull(conn, ln[:]); err != nil {
+			t.Logf("domain len: %v", err)
+			return
+		}
+		name := make([]byte, ln[0])
+		if _, err := io.ReadFull(conn, name); err != nil {
+			t.Logf("domain: %v", err)
+			return
+		}
+		host = string(name)
+	case 0x04:
+		buf := make([]byte, 16)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			t.Logf("ipv6: %v", err)
+			return
+		}
+		host = net.IP(buf).String()
+	default:
+		t.Logf("unsupported addr type %d", addrType)
+		return
+	}
+	var portBuf [2]byte
+	if _, err := io.ReadFull(conn, portBuf[:]); err != nil {
+		t.Logf("port: %v", err)
+		return
+	}
+	port := int(portBuf[0])<<8 | int(portBuf[1])
+	dest := fmt.Sprintf("%s:%d", host, port)
+	upstream, err := net.Dial("tcp", dest)
+	if err != nil {
+		t.Logf("dial dest: %v", err)
+		return
+	}
+	defer upstream.Close()
+	if _, err := conn.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		t.Logf("write success: %v", err)
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		io.Copy(upstream, conn)
+		close(done)
+	}()
+	io.Copy(conn, upstream)
+	<-done
+}

--- a/cmd/test-target/main.go
+++ b/cmd/test-target/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+type serverFlags struct {
+	listen string
+}
+
+func parseFlags() serverFlags {
+	var cfg serverFlags
+	flag.StringVar(&cfg.listen, "listen", "127.0.0.1:9000", "address to listen on")
+	flag.Parse()
+	return cfg
+}
+
+func main() {
+	cfg := parseFlags()
+	mux := newMux()
+	server := &http.Server{
+		Addr:              cfg.listen,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		s := <-sigCh
+		log.Printf("received signal %s, shutting down", s)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			log.Printf("shutdown error: %v", err)
+		}
+	}()
+
+	log.Printf("test-target listening on %s", cfg.listen)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("listen: %v", err)
+	}
+}
+
+func newMux() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+	mux.Handle("/upload", http.HandlerFunc(handleUpload))
+	return mux
+}
+
+type uploadResponse struct {
+	BytesReceived int64 `json:"bytes_received"`
+	ServerTimeMS  int64 `json:"server_time_ms"`
+}
+
+func handleUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	start := time.Now()
+	defer r.Body.Close()
+	bytesRead, err := io.Copy(io.Discard, r.Body)
+	if err != nil {
+		log.Printf("upload read error: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	resp := uploadResponse{
+		BytesReceived: bytesRead,
+		ServerTimeMS:  time.Since(start).Milliseconds(),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("encode response: %v", err)
+	}
+}

--- a/cmd/test-target/main_test.go
+++ b/cmd/test-target/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUploadEndpoint(t *testing.T) {
+	server := httptest.NewServer(newMux())
+	defer server.Close()
+	payload := bytes.Repeat([]byte("a"), 1024)
+	resp, err := http.Post(server.URL+"/upload", "application/octet-stream", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %s", resp.Status)
+	}
+	var out uploadResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.BytesReceived != int64(len(payload)) {
+		t.Fatalf("bytes received mismatch: got %d want %d", out.BytesReceived, len(payload))
+	}
+	if out.ServerTimeMS < 0 {
+		t.Fatalf("unexpected server time: %d", out.ServerTimeMS)
+	}
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	server := httptest.NewServer(newMux())
+	defer server.Close()
+	resp, err := http.Get(server.URL + "/health")
+	if err != nil {
+		t.Fatalf("get health: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %s", resp.Status)
+	}
+}


### PR DESCRIPTION
## Summary
- add test-target HTTP server CLI with /upload + /health
- add test-consumer CLI supporting direct and SOCKS uploads with timing output
- document end-to-end local workflow and add integration tests for the new tools

Closes #13

## Testing
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...