### PR TITLE
feat(metrics): add real/dummy dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,40 @@ frame.
      -file "$FILE"
    ```
 
+## Live metrics dashboards
+
+Each binary now ships with a lightweight terminal dashboard that refreshes every
+500 ms over a 10 second sliding window. Real bytes represent stream payload, and
+dummy bytes cover heartbeats, probes, frame headers, and retransmissions.
+
+- **Overlay client & server** — enabled by default (`-tui=true`). The dashboard
+  lists per-subflow transmit/receive rates split into real/dummy bytes alongside
+  aggregate totals and active stream throughput. Disable with `-tui=false` if a
+  quiet console is preferred.
+
+  ```bash
+  go run ./cmd/server -listen :8443 -cert server.crt -key server.key -tui
+  go run ./cmd/client -server 127.0.0.1:8443 -listen 127.0.0.1:1080 -tui
+  ```
+
+- **test-consumer** — shows live upload progress (bytes sent, average/instant
+  throughput, server response) with dummy bytes fixed at zero. Toggle via the
+  `-tui` flag.
+
+  ```bash
+  go run ./cmd/test-consumer -target http://127.0.0.1:9000/upload -tui
+  ```
+
+- **test-target** — reports bytes received, request rates, and the most recent
+  upload size/duration with dummy bytes fixed at zero. Toggle via `-tui`.
+
+  ```bash
+  go run ./cmd/test-target -listen 127.0.0.1:9000 -tui
+  ```
+
+Dashboards emit to stdout, so run each binary in its own terminal when
+observability is needed.
+
 ## Full local walkthrough (test harness)
 
 The repository ships two helper binaries to exercise the overlay end-to-end:

--- a/cmd/test-consumer/main_test.go
+++ b/cmd/test-consumer/main_test.go
@@ -39,7 +39,7 @@ func TestPerformUploadDirect(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	resp, elapsed, err := performUpload(ctx, client, server.URL, file)
+	resp, elapsed, err := performUpload(ctx, client, server.URL, file, nil)
 	if err != nil {
 		t.Fatalf("perform upload: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestPerformUploadViaSocks(t *testing.T) {
 	file := tempFile(t, 1024)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	resp, _, err := performUpload(ctx, client, backend.URL, file)
+	resp, _, err := performUpload(ctx, client, backend.URL, file, nil)
 	if err != nil {
 		t.Fatalf("perform upload: %v", err)
 	}

--- a/cmd/test-target/main.go
+++ b/cmd/test-target/main.go
@@ -4,29 +4,140 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/agyn-sandbox/cwnd-warm-up-proxy/internal/metrics"
+	"github.com/agyn-sandbox/cwnd-warm-up-proxy/internal/tui"
 )
 
 type serverFlags struct {
-	listen string
+	listen  string
+	showTUI bool
 }
 
 func parseFlags() serverFlags {
 	var cfg serverFlags
 	flag.StringVar(&cfg.listen, "listen", "127.0.0.1:9000", "address to listen on")
+	flag.BoolVar(&cfg.showTUI, "tui", true, "render live metrics dashboard")
 	flag.Parse()
 	return cfg
 }
 
+type targetMetrics struct {
+	listener string
+	window   time.Duration
+	step     time.Duration
+
+	rxReal    *metrics.SlidingCounter
+	reqWindow *metrics.SlidingCounter
+
+	totalReal    atomic.Int64
+	requestTotal atomic.Int64
+
+	mu          sync.Mutex
+	lastBytes   int64
+	lastAt      time.Time
+	lastLatency time.Duration
+	err         error
+}
+
+func newTargetMetrics(listener string) *targetMetrics {
+	window := 10 * time.Second
+	step := 500 * time.Millisecond
+	return &targetMetrics{
+		listener:  listener,
+		window:    window,
+		step:      step,
+		rxReal:    metrics.NewSlidingCounter(window, step),
+		reqWindow: metrics.NewSlidingCounter(window, step),
+	}
+}
+
+func (m *targetMetrics) RecordUpload(bytes int64, latency time.Duration) {
+	if m == nil {
+		return
+	}
+	m.rxReal.Add(bytes)
+	m.reqWindow.Add(1)
+	m.totalReal.Add(bytes)
+	m.requestTotal.Add(1)
+	m.mu.Lock()
+	m.lastBytes = bytes
+	m.lastLatency = latency
+	m.lastAt = time.Now()
+	m.mu.Unlock()
+}
+
+func (m *targetMetrics) RecordError(err error) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.err = err
+	m.mu.Unlock()
+}
+
+func (m *targetMetrics) Snapshot() tui.Snapshot {
+	windowSeconds := m.window.Seconds()
+	if windowSeconds <= 0 {
+		windowSeconds = 1
+	}
+	rxRate := float64(m.rxReal.Sum()) / windowSeconds
+	reqRate := float64(m.reqWindow.Sum()) / windowSeconds
+	totalBytes := m.totalReal.Load()
+	totalReq := m.requestTotal.Load()
+	lastBytes, lastLatency, lastAt, err := m.lastState()
+	lines := []string{
+		fmt.Sprintf("listening=%s", m.listener),
+		fmt.Sprintf("requests total=%d recent=%.2f/s", totalReq, reqRate),
+		fmt.Sprintf("rx real: rate=%s total=%s", tui.FormatRate(rxRate), tui.FormatBytes(totalBytes)),
+		fmt.Sprintf("rx dummy: rate=%s total=%s", tui.FormatRate(0), tui.FormatBytes(0)),
+	}
+	if !lastAt.IsZero() {
+		lines = append(lines, fmt.Sprintf(
+			"last upload: bytes=%s duration=%s ago=%s",
+			tui.FormatBytes(lastBytes),
+			tui.FormatDuration(lastLatency),
+			tui.FormatDuration(time.Since(lastAt)),
+		))
+	} else {
+		lines = append(lines, "last upload: none yet")
+	}
+	if err != nil {
+		lines = append(lines, fmt.Sprintf("error: %v", err))
+	}
+	return tui.Snapshot{
+		Timestamp: time.Now(),
+		Title:     "test-target",
+		Lines:     lines,
+	}
+}
+
+func (m *targetMetrics) lastState() (bytes int64, latency time.Duration, at time.Time, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastBytes, m.lastLatency, m.lastAt, m.err
+}
+
 func main() {
 	cfg := parseFlags()
-	mux := newMux()
+	metrics := newTargetMetrics(cfg.listen)
+	var dashboard *tui.Dashboard
+	if cfg.showTUI {
+		dashboard = tui.NewDashboard(metrics, os.Stdout, 500*time.Millisecond)
+		dashboard.Start()
+		defer dashboard.Stop()
+	}
+	mux := newMux(metrics)
 	server := &http.Server{
 		Addr:              cfg.listen,
 		Handler:           mux,
@@ -47,17 +158,22 @@ func main() {
 
 	log.Printf("test-target listening on %s", cfg.listen)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if metrics != nil {
+			metrics.RecordError(err)
+		}
 		log.Fatalf("listen: %v", err)
 	}
 }
 
-func newMux() http.Handler {
+func newMux(metrics *targetMetrics) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok\n"))
 	})
-	mux.Handle("/upload", http.HandlerFunc(handleUpload))
+	mux.Handle("/upload", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleUpload(w, r, metrics)
+	}))
 	return mux
 }
 
@@ -66,7 +182,7 @@ type uploadResponse struct {
 	ServerTimeMS  int64 `json:"server_time_ms"`
 }
 
-func handleUpload(w http.ResponseWriter, r *http.Request) {
+func handleUpload(w http.ResponseWriter, r *http.Request, metrics *targetMetrics) {
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -76,15 +192,25 @@ func handleUpload(w http.ResponseWriter, r *http.Request) {
 	bytesRead, err := io.Copy(io.Discard, r.Body)
 	if err != nil {
 		log.Printf("upload read error: %v", err)
+		if metrics != nil {
+			metrics.RecordError(err)
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	latency := time.Since(start)
+	if metrics != nil {
+		metrics.RecordUpload(bytesRead, latency)
+	}
 	resp := uploadResponse{
 		BytesReceived: bytesRead,
-		ServerTimeMS:  time.Since(start).Milliseconds(),
+		ServerTimeMS:  latency.Milliseconds(),
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		log.Printf("encode response: %v", err)
+		if metrics != nil {
+			metrics.RecordError(err)
+		}
 	}
 }

--- a/cmd/test-target/main_test.go
+++ b/cmd/test-target/main_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestUploadEndpoint(t *testing.T) {
-	server := httptest.NewServer(newMux())
+	server := httptest.NewServer(newMux(nil))
 	defer server.Close()
 	payload := bytes.Repeat([]byte("a"), 1024)
 	resp, err := http.Post(server.URL+"/upload", "application/octet-stream", bytes.NewReader(payload))
@@ -33,7 +33,7 @@ func TestUploadEndpoint(t *testing.T) {
 }
 
 func TestHealthEndpoint(t *testing.T) {
-	server := httptest.NewServer(newMux())
+	server := httptest.NewServer(newMux(nil))
 	defer server.Close()
 	resp, err := http.Get(server.URL + "/health")
 	if err != nil {

--- a/internal/overlay/scheduler.go
+++ b/internal/overlay/scheduler.go
@@ -55,7 +55,7 @@ const (
 
 func (s *Scheduler) refreshWeightsLocked() {
 	for _, entry := range s.entries {
-		throughput := entry.ref.tx.Sum()
+		throughput := entry.ref.txReal.Sum()
 		weight := weightFromThroughput(throughput)
 		if weight != entry.weight {
 			entry.weight = weight

--- a/internal/overlay/scheduler_test.go
+++ b/internal/overlay/scheduler_test.go
@@ -10,15 +10,15 @@ import (
 func TestSchedulerWeightsFollowGoodput(t *testing.T) {
 	sched := NewScheduler()
 	fast := &Subflow{
-		ID: 0,
-		tx: metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
+		ID:     0,
+		txReal: metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
 	}
 	slow := &Subflow{
-		ID: 1,
-		tx: metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
+		ID:     1,
+		txReal: metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
 	}
-	fast.tx.Add(int64(weightQuantum) * 10)
-	slow.tx.Add(int64(weightQuantum) / 10)
+	fast.txReal.Add(int64(weightQuantum) * 10)
+	slow.txReal.Add(int64(weightQuantum) / 10)
 
 	sched.Attach(fast)
 	sched.Attach(slow)

--- a/internal/overlay/stream_test.go
+++ b/internal/overlay/stream_test.go
@@ -23,8 +23,10 @@ func TestStreamOnAckTriggersRetransmitForSACKHole(t *testing.T) {
 		Conn:    conn,
 		session: sess,
 		closed:  make(chan struct{}),
-		tx:      metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
-		rx:      metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
+		txReal:  metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
+		txDummy: metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
+		rxReal:  metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
+		rxDummy: metrics.NewSlidingCounter(10*time.Second, 500*time.Millisecond),
 	}
 	sess.scheduler.Attach(sf)
 

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -1,0 +1,53 @@
+package tui
+
+import (
+	"fmt"
+	"time"
+)
+
+var units = []struct {
+	suffix string
+	value  float64
+}{
+	{"GiB", 1 << 30},
+	{"MiB", 1 << 20},
+	{"KiB", 1 << 10},
+}
+
+// FormatRate renders a bytes-per-second value using human readable units.
+func FormatRate(bps float64) string {
+	if bps < 0 {
+		bps = 0
+	}
+	for _, unit := range units {
+		if bps >= unit.value {
+			return fmt.Sprintf("%.2f %s/s", bps/unit.value, unit.suffix)
+		}
+	}
+	return fmt.Sprintf("%.2f B/s", bps)
+}
+
+// FormatBytes renders a byte total using human readable units.
+func FormatBytes(bytes int64) string {
+	if bytes < 0 {
+		bytes = 0
+	}
+	value := float64(bytes)
+	for _, unit := range units {
+		if value >= unit.value {
+			return fmt.Sprintf("%.2f %s", value/unit.value, unit.suffix)
+		}
+	}
+	return fmt.Sprintf("%d B", bytes)
+}
+
+// FormatDuration renders durations with millisecond or second precision.
+func FormatDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.2fs", d.Seconds())
+}


### PR DESCRIPTION
## Summary
- track real and dummy throughput per subflow and stream for the overlay
- add live 500ms/10s dashboards to client, server, test-consumer, and test-target
- document the metrics dashboards in the README

## Testing
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...

Closes #18
